### PR TITLE
Fix nil pointer dereference in flows create command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ var rootCmd = &cobra.Command{
 		if cmd.Name() == "config" || cmd.Name() == "version" || cmd.Name() == "help" ||
 			cmd.Name() == "set-token" || cmd.Name() == "set-host" || cmd.Name() == "show" ||
 			cmd.Name() == "completion" || cmd.Name() == "ai" || cmd.Name() == "scopes" ||
-			cmd.Name() == "login" || cmd.Name() == "create" || cmdPath == "homeyctl" {
+			cmd.Name() == "login" || cmdPath == "homeyctl token create" || cmdPath == "homeyctl" {
 			return nil
 		}
 


### PR DESCRIPTION
## Summary
- Fixed segmentation fault when running `homeyctl flows create` or `homeyctl flows create --advanced`
- The bug was caused by `cmd.Name() == "create"` matching all "create" commands, not just `token create`
- Added comprehensive tests for config loading logic (27 test cases)

## Test plan
- [x] All existing tests pass
- [x] New tests verify `flows create` initializes apiClient correctly
- [x] New tests verify `token create` still skips config loading (handles its own OAuth)
- [x] Lint passes

Fixes #4
Fixes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading behavior for specific CLI commands, ensuring proper handling of configuration initialization during command execution.

* **Tests**
  * Added comprehensive unit tests to verify configuration loading behavior across various command paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->