### PR TITLE
Add device settings management commands

### DIFF
--- a/cmd/ai.go
+++ b/cmd/ai.go
@@ -79,8 +79,14 @@ homeyctl login
 homeyctl devices list                  # List all devices
 homeyctl devices get <id>              # Get device details
 homeyctl devices set <id> <capability> <value>  # Control device
+homeyctl devices get-settings <id>     # Get device settings
+homeyctl devices set-setting <id> <key> <value>  # Set device setting
 homeyctl devices delete <name-or-id>   # Delete a device
 ` + "```" + `
+
+**Note on Device Settings**: Settings (like ` + "`zone_activity_disabled`" + `) require full ` + "`homey.device`" + ` scope.
+OAuth tokens only support ` + "`homey.device.control`" + `. For settings access, create an API key
+at https://my.homey.app (Select Homey → Settings → API Keys).
 
 ### Flows
 ` + "```" + `bash

--- a/cmd/devices.go
+++ b/cmd/devices.go
@@ -176,6 +176,152 @@ Examples:
 	},
 }
 
+var devicesSetSettingCmd = &cobra.Command{
+	Use:   "set-setting <name-or-id> <setting-key> <value>",
+	Short: "Set device setting",
+	Long: `Set a device setting value.
+
+Device settings are different from capabilities - they configure device behavior
+rather than control it. Common settings include:
+  - zone_activity_disabled: Exclude sensor from zone activity detection
+  - climate_exclude: Exclude device from climate control
+
+Examples:
+  homeyctl devices set-setting "Motion Sensor" zone_activity_disabled true
+  homeyctl devices set-setting "Thermostat" climate_exclude false`,
+	Args: cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nameOrID := args[0]
+		settingKey := args[1]
+		valueStr := args[2]
+
+		// Find device ID
+		data, err := apiClient.GetDevices()
+		if err != nil {
+			return err
+		}
+
+		var devices map[string]Device
+		if err := json.Unmarshal(data, &devices); err != nil {
+			return fmt.Errorf("failed to parse devices: %w", err)
+		}
+
+		var deviceID, deviceName string
+		for _, d := range devices {
+			if d.ID == nameOrID || strings.EqualFold(d.Name, nameOrID) {
+				deviceID = d.ID
+				deviceName = d.Name
+				break
+			}
+		}
+
+		if deviceID == "" {
+			return fmt.Errorf("device not found: %s", nameOrID)
+		}
+
+		// Parse value
+		var value interface{}
+		if valueStr == "true" {
+			value = true
+		} else if valueStr == "false" {
+			value = false
+		} else {
+			// Try as number
+			var num float64
+			if _, err := fmt.Sscanf(valueStr, "%f", &num); err == nil {
+				value = num
+			} else {
+				value = valueStr
+			}
+		}
+
+		settings := map[string]interface{}{
+			settingKey: value,
+		}
+
+		if err := apiClient.SetDeviceSetting(deviceID, settings); err != nil {
+			if strings.Contains(err.Error(), "Missing Scopes") {
+				return fmt.Errorf(`permission denied: changing device settings requires 'homey.device' scope
+
+OAuth tokens only support 'homey.device.control' (for on/off, dim, etc.),
+not full device access needed for settings.
+
+To change device settings, create an API key at my.homey.app:
+  1. Go to https://my.homey.app
+  2. Select your Homey → Settings → API Keys
+  3. Create a new API key (it will have full access)
+  4. Run: homeyctl config set-token <your-api-key>`)
+			}
+			return err
+		}
+
+		fmt.Printf("Set %s setting %s = %v\n", deviceName, settingKey, value)
+		return nil
+	},
+}
+
+var devicesGetSettingsCmd = &cobra.Command{
+	Use:   "get-settings <name-or-id>",
+	Short: "Get device settings",
+	Long: `Get all settings for a device.
+
+This shows configurable settings like zone_activity_disabled, climate_exclude,
+and driver-specific settings.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nameOrID := args[0]
+
+		// Find device ID
+		data, err := apiClient.GetDevices()
+		if err != nil {
+			return err
+		}
+
+		var devices map[string]Device
+		if err := json.Unmarshal(data, &devices); err != nil {
+			return fmt.Errorf("failed to parse devices: %w", err)
+		}
+
+		var deviceID, deviceName string
+		for _, d := range devices {
+			if d.ID == nameOrID || strings.EqualFold(d.Name, nameOrID) {
+				deviceID = d.ID
+				deviceName = d.Name
+				break
+			}
+		}
+
+		if deviceID == "" {
+			return fmt.Errorf("device not found: %s", nameOrID)
+		}
+
+		settings, err := apiClient.GetDeviceSettings(deviceID)
+		if err != nil {
+			return err
+		}
+
+		if isTableFormat() {
+			var settingsMap map[string]interface{}
+			if err := json.Unmarshal(settings, &settingsMap); err != nil {
+				return fmt.Errorf("failed to parse settings: %w", err)
+			}
+
+			fmt.Printf("Settings for %s:\n\n", deviceName)
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "SETTING\tVALUE")
+			fmt.Fprintln(w, "-------\t-----")
+			for key, val := range settingsMap {
+				fmt.Fprintf(w, "%s\t%v\n", key, val)
+			}
+			w.Flush()
+			return nil
+		}
+
+		outputJSON(settings)
+		return nil
+	},
+}
+
 var devicesDeleteCmd = &cobra.Command{
 	Use:   "delete <name-or-id>",
 	Short: "Delete a device",
@@ -214,5 +360,7 @@ func init() {
 	devicesCmd.AddCommand(devicesListCmd)
 	devicesCmd.AddCommand(devicesGetCmd)
 	devicesCmd.AddCommand(devicesSetCmd)
+	devicesCmd.AddCommand(devicesSetSettingCmd)
+	devicesCmd.AddCommand(devicesGetSettingsCmd)
 	devicesCmd.AddCommand(devicesDeleteCmd)
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -88,6 +88,15 @@ func (c *Client) DeleteDevice(id string) error {
 	return err
 }
 
+func (c *Client) GetDeviceSettings(id string) (json.RawMessage, error) {
+	return c.doRequest("GET", fmt.Sprintf("/api/manager/devices/device/%s/settings_obj", id), nil)
+}
+
+func (c *Client) SetDeviceSetting(deviceID string, settings map[string]interface{}) error {
+	_, err := c.doRequest("PUT", fmt.Sprintf("/api/manager/devices/device/%s/settings", deviceID), settings)
+	return err
+}
+
 // Flows
 
 func (c *Client) GetFlows() (json.RawMessage, error) {


### PR DESCRIPTION
## Summary

Closes #3

Adds two new commands for managing device settings:
- `homeyctl devices get-settings <name-or-id>` - View all settings for a device
- `homeyctl devices set-setting <name-or-id> <key> <value>` - Modify a device setting

Also updates `homeyctl ai` with documentation for these commands.

## Important: OAuth Scope Limitation

@fishfisher - heads up on a discovery during implementation:

**Athom's OAuth system does NOT support the `homey.device` scope** required for changing device settings. The only available device scopes are:
- `homey.device.readonly` - read device info
- `homey.device.control` - control devices (on/off, dim, etc.)

This means **OAuth tokens (from `homeyctl login`) cannot modify device settings**.

### Workaround

Users who need to change device settings must create an API key at my.homey.app:
1. Go to https://my.homey.app
2. Select your Homey → Settings → API Keys
3. Create a new API key (has full access)
4. Run: `homeyctl config set-token <api-key>`

The CLI includes a clear error message explaining this when users hit the "Missing Scopes" error.

## Test plan

- [x] Tested `devices get-settings` against real Homey
- [x] Tested `devices set-setting` against real Homey with API key
- [x] Verified clear error message when using OAuth token without required scope
- [x] Updated `homeyctl ai` documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device settings commands to retrieve and update device settings from the CLI.
* **Documentation**
  * Added guidance on required permissions and authentication (scope and token differences) for accessing device settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->